### PR TITLE
fix: run app on startup

### DIFF
--- a/OpenXRRuntimeSwitcher.Tests/Fakes/FakeTaskSchedulerService.cs
+++ b/OpenXRRuntimeSwitcher.Tests/Fakes/FakeTaskSchedulerService.cs
@@ -1,0 +1,22 @@
+﻿using OpenXRRuntimeSwitcher.Services.Abstractions;
+
+namespace OpenXRRuntimeSwitcher.Tests.Fakes;
+
+public sealed class FakeTaskSchedulerService : ITaskSchedulerService
+{
+    public sealed record TaskRecord(string TaskName, string ExePath, string UserName);
+
+    public readonly Dictionary<string, TaskRecord> Tasks = new();
+
+    public bool TaskExists(string taskName) => Tasks.ContainsKey(taskName);
+
+    public void CreateTask(string taskName, string exePath, string userName)
+    {
+        Tasks[taskName] = new TaskRecord(taskName, exePath, userName);
+    }
+
+    public void DeleteTask(string taskName)
+    {
+        Tasks.Remove(taskName);
+    }
+}

--- a/OpenXRRuntimeSwitcher.Tests/Unit/Services/StartupTaskServiceTests.cs
+++ b/OpenXRRuntimeSwitcher.Tests/Unit/Services/StartupTaskServiceTests.cs
@@ -1,0 +1,73 @@
+﻿using OpenXRRuntimeSwitcher.Services;
+using OpenXRRuntimeSwitcher.Tests.Fakes;
+
+public sealed class StartupTaskServiceTests
+{
+    private StartupTaskService CreateService(FakeTaskSchedulerService fake)
+        => new StartupTaskService(fake);
+
+    [Fact]
+    public void TaskExists_ReturnsFalse_WhenNoTask()
+    {
+        var fake = new FakeTaskSchedulerService();
+        var sut = CreateService(fake);
+
+        Assert.False(sut.TaskExists());
+    }
+
+    [Fact]
+    public void CreateTask_AddsTaskWithCorrectParameters()
+    {
+        var fake = new FakeTaskSchedulerService();
+        var fakeExe = @"C:\Apps\OpenXRRuntimeSwitcher.exe";
+
+        var sut = new StartupTaskService(fake, fakeExe);
+
+        sut.CreateTask();
+
+        Assert.True(fake.TaskExists("OpenXRRuntimeSwitcher_AutoStart"));
+
+        var record = fake.Tasks["OpenXRRuntimeSwitcher_AutoStart"];
+
+        Assert.Equal(fakeExe, record.ExePath);
+        Assert.Contains(Environment.UserName, record.UserName);
+    }
+
+    [Fact]
+    public void DeleteTask_RemovesTask()
+    {
+        var fake = new FakeTaskSchedulerService();
+        var sut = CreateService(fake);
+
+        sut.CreateTask();
+        Assert.True(sut.TaskExists());
+
+        sut.DeleteTask();
+        Assert.False(sut.TaskExists());
+    }
+
+    [Fact]
+    public void CreateTask_OverwritesExistingTaskDoesNotHappen()
+    {
+        var fake = new FakeTaskSchedulerService();
+        var sut = CreateService(fake);
+
+        sut.CreateTask();
+        var first = fake.Tasks["OpenXRRuntimeSwitcher_AutoStart"];
+
+        sut.CreateTask();
+        var second = fake.Tasks["OpenXRRuntimeSwitcher_AutoStart"];
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void DeleteTask_DoesNotThrow_WhenTaskDoesNotExist()
+    {
+        var fake = new FakeTaskSchedulerService();
+        var sut = CreateService(fake);
+
+        var ex = Record.Exception(() => sut.DeleteTask());
+        Assert.Null(ex);
+    }
+}

--- a/OpenXRRuntimeSwitcher/OpenXRRuntimeSwitcher.csproj
+++ b/OpenXRRuntimeSwitcher/OpenXRRuntimeSwitcher.csproj
@@ -20,6 +20,9 @@
 	  <None Remove="tests\**" />
 	</ItemGroup>
 	<ItemGroup>
+	  <PackageReference Include="TaskScheduler" Version="2.12.2" />
+	</ItemGroup>
+	<ItemGroup>
 	  <Compile Update="Properties\Resources.Designer.cs">
 	    <DesignTime>True</DesignTime>
 	    <AutoGen>True</AutoGen>

--- a/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/Abstractions/ITaskSchedulerService.cs
+++ b/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/Abstractions/ITaskSchedulerService.cs
@@ -1,0 +1,8 @@
+﻿namespace OpenXRRuntimeSwitcher.Services.Abstractions;
+
+public interface ITaskSchedulerService
+{
+    bool TaskExists(string taskName);
+    void CreateTask(string taskName, string exePath, string userName);
+    void DeleteTask(string taskName);
+}

--- a/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/StartupTaskService.cs
+++ b/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/StartupTaskService.cs
@@ -1,0 +1,37 @@
+﻿using OpenXRRuntimeSwitcher.Services.Abstractions;
+using System.Security.Principal;
+
+namespace OpenXRRuntimeSwitcher.Services;
+public sealed class StartupTaskService
+{
+    private const string TaskName = "OpenXRRuntimeSwitcher_AutoStart";
+
+    private readonly ITaskSchedulerService _scheduler;
+    private readonly string _exePath;
+    private readonly string _userName;
+
+    public StartupTaskService(ITaskSchedulerService scheduler, string? exePathOverride = null)
+    {
+        _scheduler = scheduler;
+        _exePath = exePathOverride
+                   ?? System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName
+                   ?? throw new InvalidOperationException("Unable to determine executable path.");
+
+        _userName = WindowsIdentity.GetCurrent().Name;
+    }
+
+    public bool TaskExists() => _scheduler.TaskExists(TaskName);
+
+    public void CreateTask()
+    {
+        if (TaskExists())
+        {
+            TrayLogger.Log("Startup task already exists, skipping creation.");
+            return;
+        }
+        _scheduler.CreateTask(TaskName, _exePath, _userName);
+        TrayLogger.Log("Startup task created successfully, with executable path: " + _exePath);
+    }
+
+    public void DeleteTask() => _scheduler.DeleteTask(TaskName);
+}

--- a/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/TaskSchedulerService.cs
+++ b/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/Services/TaskSchedulerService.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Win32.TaskScheduler;
+using OpenXRRuntimeSwitcher.Services.Abstractions;
+
+namespace OpenXRRuntimeSwitcher.Services;
+
+public sealed class TaskSchedulerService : ITaskSchedulerService
+{
+    public bool TaskExists(string taskName)
+    {
+        using var ts = new TaskService();
+        return ts.GetTask(taskName) != null;
+    }
+
+    public void CreateTask(string taskName, string exePath, string userName)
+    {
+        using var ts = new TaskService();
+
+        var td = ts.NewTask();
+        td.RegistrationInfo.Description = "Automatically starts OpenXRRuntimeSwitcher at logon with elevation.";
+
+        td.Triggers.Add(new LogonTrigger());
+        td.Principal.RunLevel = TaskRunLevel.Highest;
+        td.Principal.UserId = userName;
+
+        td.Actions.Add(new ExecAction(exePath, null, Path.GetDirectoryName(exePath)));
+
+        ts.RootFolder.RegisterTaskDefinition(taskName, td);
+    }
+
+    public void DeleteTask(string taskName)
+    {
+        using var ts = new TaskService();
+        ts.RootFolder.DeleteTask(taskName, false);
+    }
+}

--- a/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/TrayApp.cs
+++ b/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/TrayApp.cs
@@ -1,4 +1,3 @@
-using Microsoft.Win32;
 using OpenXRRuntimeSwitcher.Models;
 using OpenXRRuntimeSwitcher.Properties;
 using OpenXRRuntimeSwitcher.Services;
@@ -12,6 +11,7 @@ namespace OpenXRRuntimeSwitcher
         private readonly IHotkeyService _hotkeyService;
         private readonly IRuntimeInfoProvider _runtimeInfoProvider;
         private readonly Config _config;
+        private readonly StartupTaskService _startupTaskService = new(new TaskSchedulerService());
 
         private IReadOnlyList<OpenXRRuntime> _runtimes = Array.Empty<OpenXRRuntime>();
 
@@ -50,8 +50,8 @@ namespace OpenXRRuntimeSwitcher
             _registryDetector.Changed += OnRegistryChanged;
             _registryDetector.Start();
 
-            _startupCheckbox.Checked = IsStartupEnabled();
-
+            TrayLogger.Log("Checking for existing startup: " + (_startupTaskService.TaskExists() ? "Exists" : "Does not exist"));
+            _startupCheckbox.Checked = _startupTaskService.TaskExists();
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -213,33 +213,6 @@ namespace OpenXRRuntimeSwitcher
             catch (Exception ex)
             {
                 TrayLogger.LogException(nameof(OnRegistryChanged), ex);
-            }
-        }
-
-        // Returns whether the app is configured to run at current-user startup
-        private bool IsStartupEnabled()
-        {
-            try
-            {
-                const string runKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
-                const string valueName = "OpenXRRuntimeSwitcher";
-
-                using var key = Registry.CurrentUser.OpenSubKey(runKey, writable: false);
-                if (key is null) return false;
-
-                var value = key.GetValue(valueName)?.ToString();
-                if (string.IsNullOrWhiteSpace(value)) return false;
-
-                // Normalize stored value and current exe path for comparison
-                var stored = value.Trim().Trim('"');
-                var exe = Application.ExecutablePath?.Trim().Trim('"') ?? string.Empty;
-                return string.Equals(stored, exe, StringComparison.OrdinalIgnoreCase)
-                       || Path.GetFileNameWithoutExtension(stored).Equals(Path.GetFileNameWithoutExtension(exe), StringComparison.OrdinalIgnoreCase);
-            }
-            catch (Exception ex)
-            {
-                TrayLogger.LogException(nameof(IsStartupEnabled), ex);
-                return false;
             }
         }
     }

--- a/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/TrayApp.handlers.cs
+++ b/OpenXRRuntimeSwitcher/src/OpenXRRuntimeSwitcher/TrayApp.handlers.cs
@@ -1,4 +1,3 @@
-using Microsoft.Win32;
 using OpenXRRuntimeSwitcher.Services;
 
 namespace OpenXRRuntimeSwitcher
@@ -65,44 +64,31 @@ namespace OpenXRRuntimeSwitcher
         // Toggle whether the app runs at current-user startup (HKCU\...\Run)
         // Later on, we will likely only elevate when the user clicks "Apply",
         // for now we will just toggle the registry key and let the user deal with UAC if they have it enabled.
-        private void ToggleStartup(bool enable)
+        private bool ToggleStartup(bool enable)
         {
-            const string runKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
-            const string valueName = "OpenXRRuntimeSwitcher";
-
             try
             {
-                using var key = Registry.CurrentUser.OpenSubKey(runKey, writable: true) ?? Registry.CurrentUser.CreateSubKey(runKey);
-                if (key is null)
-                {
-                    TrayLogger.Log("Failed to open/create Run registry key for startup toggle.");
-                    return;
-                }
-
                 if (enable)
-                {
-                    var exePath = $"\"{Application.ExecutablePath}\"";
-                    key.SetValue(valueName, exePath, RegistryValueKind.String);
-                    TrayLogger.Log("Enabled startup.");
-                }
+                    _startupTaskService.CreateTask();
                 else
-                {
-                    if (key.GetValueNames().Length > 0 && key.GetValue(valueName) is not null)
-                    {
-                        key.DeleteValue(valueName, throwOnMissingValue: false);
-                        TrayLogger.Log("Disabled startup.");
-                    }
-                }
+                    _startupTaskService.DeleteTask();
             }
             catch (Exception ex)
             {
-                TrayLogger.LogException(nameof(ToggleStartup), ex);
-                MessageBox.Show(this, $"Failed to update startup setting: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                // Revert checkbox state to reflect reality - use named handler (designer-safe)
-                _startupCheckbox.CheckedChanged -= StartupCheckbox_CheckedChanged;
-                _startupCheckbox.Checked = IsStartupEnabled();
-                _startupCheckbox.CheckedChanged += StartupCheckbox_CheckedChanged;
+                MessageBox.Show(
+                    $"Failed to update startup task:\n\n{ex.Message}",
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error
+                );
+
+                TrayLogger.LogException("Error toggling startup task", ex);
+
+                // Revert checkbox to actual state
+                return _startupTaskService.TaskExists();
             }
+
+            return _startupTaskService.TaskExists();
         }
 
         protected override void OnResize(EventArgs e)


### PR DESCRIPTION
Closes #4 

Reworks the start-up mechanism to use a task rather than the registry which allows for UAC avoidance.  Extracted those components to allow for better testing and verified all is working.